### PR TITLE
Expose `UIPreviewCatalogConfig` initialiser.

### DIFF
--- a/Sources/UIPreviewCatalog/UIPreviewCatalogConfig.swift
+++ b/Sources/UIPreviewCatalog/UIPreviewCatalogConfig.swift
@@ -14,7 +14,7 @@ public struct UIPreviewCatalogConfig {
     public let markdownImageLinkHeight: Float?
     public let previewCatalogFilename: String
     
-    init(directoryName: String,
+    public init(directoryName: String,
          imageDirectoryName: String,
          markdownImageLinkWidth: Float?,
          markdownImageLinkHeight: Float?,


### PR DESCRIPTION
Without exposing `UIPreviewCatalogConfig` initialiser custom configurations are not possible. 