### PR TITLE
Add `snapshotFilename` to `UIPreviewCatalogConfig`.

### DIFF
--- a/Sources/UIPreviewCatalog/PreviewItem.swift
+++ b/Sources/UIPreviewCatalog/PreviewItem.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 /// Preview Information
 public struct PreviewItem {
-    let name: String
+    public let name: String
     let previews: [_Preview]
     
     public init(name: String, previews: [_Preview]){

--- a/Sources/UIPreviewCatalog/UIPreviewCatalog.swift
+++ b/Sources/UIPreviewCatalog/UIPreviewCatalog.swift
@@ -95,12 +95,7 @@ public class UIPreviewCatalog {
     }
 
     private func generateSnapshotFilename(item: PreviewItem, preview: _Preview, previewIndex: Int) -> String {
-        var fileName = "\(item.name)_\(previewIndex+1)"
-        if let displayName = preview.displayName {
-            fileName += "_\(displayName)"
-        }
-        
-        return fileName
+        config.snapshotFilename.generateSnapshotFilename(item: item, preview: preview, previewIndex: previewIndex)
     }
 
     private func saveSnapshot(of view: UIView, with name: String) throws {

--- a/Sources/UIPreviewCatalog/UIPreviewCatalogConfig.swift
+++ b/Sources/UIPreviewCatalog/UIPreviewCatalogConfig.swift
@@ -10,17 +10,20 @@
 public struct UIPreviewCatalogConfig {
     public let baseDirectoryName: String
     public let snapshotsDirectoryName: String
+    public let snapshotFilename: UIPreviewCatalogFilename
     public let markdownImageLinkWidth: Float?
     public let markdownImageLinkHeight: Float?
     public let previewCatalogFilename: String
-    
+
     public init(directoryName: String,
          imageDirectoryName: String,
+         imageFilename: UIPreviewCatalogFilename,
          markdownImageLinkWidth: Float?,
          markdownImageLinkHeight: Float?,
          previewCatalogFilename: String) {
         self.baseDirectoryName = directoryName
         self.snapshotsDirectoryName = imageDirectoryName
+        self.snapshotFilename = imageFilename
         self.markdownImageLinkWidth = markdownImageLinkWidth
         self.markdownImageLinkHeight = markdownImageLinkHeight
         self.previewCatalogFilename = previewCatalogFilename
@@ -30,6 +33,7 @@ public struct UIPreviewCatalogConfig {
 extension UIPreviewCatalogConfig {
     public static let defaultConfig: Self = .init(directoryName: "UIPreviewCatalog",
                                            imageDirectoryName: "Images",
+                                           imageFilename: UIPreviewCatalogFilenameDefault(),
                                            markdownImageLinkWidth: 200,
                                            markdownImageLinkHeight: nil,
                                            previewCatalogFilename: "previewCatalog")

--- a/Sources/UIPreviewCatalog/UIPreviewCatalogFilename.swift
+++ b/Sources/UIPreviewCatalog/UIPreviewCatalogFilename.swift
@@ -1,0 +1,16 @@
+import Foundation
+import SwiftUI
+
+public protocol UIPreviewCatalogFilename {
+    func generateSnapshotFilename(item: PreviewItem, preview: _Preview, previewIndex: Int) -> String
+}
+
+struct UIPreviewCatalogFilenameDefault: UIPreviewCatalogFilename {
+    func generateSnapshotFilename(item: PreviewItem, preview: _Preview, previewIndex: Int) -> String {
+        var fileName = "\(item.name)_\(previewIndex+1)"
+        if let displayName = preview.displayName {
+            fileName += "_\(displayName)"
+        }
+        return fileName
+    }
+}


### PR DESCRIPTION
We're combining output snapshots with [swift-snapshot-testing](https://github.com/pointfreeco/swift-snapshot-testing) to run tests. 

However the library uses dot syntax for filenames rather than underscores: [AssertSnapshot.swift#L201](https://github.com/pointfreeco/swift-snapshot-testing/blob/main/Sources/SnapshotTesting/AssertSnapshot.swift#L201)

This PR opens up configuring the file name by the owner. 